### PR TITLE
Map AnyType to kotlin.String

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
@@ -415,6 +415,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
         typeMapping.put("binary", "OctetByteArray");
         typeMapping.put("ByteArray", "Base64ByteArray");
         typeMapping.put("object", "kotlin.String");  // kotlin.Any not serializable
+        typeMapping.put("AnyType", "kotlin.String");  // kotlin.Any not serializable
 
         // Multiplatform import mapping
         importMapping.put("BigDecimal", "kotlin.Double");


### PR DESCRIPTION
Using a spec with this model spec

```
"TestModel": {
  "type": "object",
  "properties": {
    "ext": {
      "nullable": true
    }
  },
  "additionalProperties": false
},
```

would previously generate invalid Kotlin code referencing the type `AnyType` for the property `ext`.