### PR TITLE
Generate a valid ApiClient.kt when a custom apiPackage is specified

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/ApiClient.kt.mustache
@@ -6,7 +6,7 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 import kotlinx.serialization.json.Json
-import {{packageName}}.apis.*
+import {{apiPackage}}.*
 import {{packageName}}.infrastructure.ApiClientBase
 
 {{! TODO: Remove when backticks problems are resolved }}


### PR DESCRIPTION
`apiPackage` / `--api-package` is [a core parameter of the generator](https://openapi-generator.tech/docs/usage/#generate). When specified, `api.mustache` respects it but `ApiClient.kt.mustache` is generated with an invalid import.