### PR TITLE
Support customizing kotlinx serialization version

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
@@ -29,6 +29,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
         public static final String KOTLIN_VERSION = "kotlinVersion";
         public static final String KTOR_VERSION = "ktorVersion";
         public static final String KOTLINX_COROUTINES_VERSION = "kotlinxCoroutinesVersion";
+        public static final String KOTLINX_SERIALIZATION_VERSION = "kotlinxSerializationVersion";
         public static final String GRADLE_VERSION = "gradleVersion";
         public static final String ANDROID_GRADLE_VERSION = "androidGradleVersion";
         public static final String KOTLINX_DATETIME_VERSION = "kotlinxDatetimeVersion";
@@ -50,6 +51,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
             public static final String KOTLIN_VERSION = "1.4.21";
             public static final String KTOR_VERSION = "1.4.1";
             public static final String KOTLINX_COROUTINES_VERSION = "1.4.1";
+            public static final String KOTLINX_SERIALIZATION_VERSION = "1.0.1";
             public static final String GRADLE_VERSION = "6.6.1";
             public static final String ANDROID_GRADLE_VERSION = "4.0.1";
             public static final String KOTLINX_DATETIME_VERSION = "0.1.1";
@@ -247,6 +249,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
         cliOptions.add(CliOption.newString(Options.KOTLIN_VERSION, "Sets the kotlin version used").defaultValue(Options.Defaults.KOTLIN_VERSION));
         cliOptions.add(CliOption.newString(Options.KTOR_VERSION, "Sets the ktor version used").defaultValue(Options.Defaults.KTOR_VERSION));
         cliOptions.add(CliOption.newString(Options.KOTLINX_COROUTINES_VERSION, "Sets the kotlinx.coroutines version used").defaultValue(Options.Defaults.KOTLINX_COROUTINES_VERSION));
+        cliOptions.add(CliOption.newString(Options.KOTLINX_SERIALIZATION_VERSION, "Sets the kotlinx.serialization version used").defaultValue(Options.Defaults.KOTLINX_SERIALIZATION_VERSION));
         cliOptions.add(CliOption.newString(Options.GRADLE_VERSION, "Sets the gradle version used").defaultValue(Options.Defaults.GRADLE_VERSION));
         cliOptions.add(CliOption.newString(Options.ANDROID_GRADLE_VERSION, "Sets the android gradle plugin version used").defaultValue(Options.Defaults.ANDROID_GRADLE_VERSION));
 
@@ -319,6 +322,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
         String kotlinVersion = stringOption(Options.KOTLIN_VERSION, Options.Defaults.KOTLIN_VERSION);
         String ktorVersion = stringOption(Options.KTOR_VERSION, Options.Defaults.KTOR_VERSION);
         String kotlinxCoroutinesVersion = stringOption(Options.KOTLINX_COROUTINES_VERSION, Options.Defaults.KOTLINX_COROUTINES_VERSION);
+        String kotlinxSerializationVersion = stringOption(Options.KOTLINX_SERIALIZATION_VERSION, Options.Defaults.KOTLINX_SERIALIZATION_VERSION);
         String gradleVersion = stringOption(Options.GRADLE_VERSION, Options.Defaults.GRADLE_VERSION);
         String androidGradleVersion = stringOption(Options.ANDROID_GRADLE_VERSION, Options.Defaults.ANDROID_GRADLE_VERSION);
         String kotlinxDatetimeVersion = stringOption(Options.KOTLINX_DATETIME_VERSION, Options.Defaults.KOTLINX_DATETIME_VERSION);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
@@ -45,11 +45,12 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
 
         public static final class Defaults {
             // Versions
-            public static final String KOTLIN_VERSION = "1.4.10";
-            public static final String KTOR_VERSION = "1.4.0";
+            // Recommended choices: https://kotlinlang.org/releases.html
+            public static final String KOTLIN_VERSION = "1.4.21";
+            public static final String KTOR_VERSION = "1.4.1";
             public static final String GRADLE_VERSION = "6.6.1";
             public static final String ANDROID_GRADLE_VERSION = "4.0.1";
-            public static final String KOTLINX_DATETIME_VERSION = "0.1.0";
+            public static final String KOTLINX_DATETIME_VERSION = "0.1.1";
 
             // Platforms specific options
             // Default choices: https://www.jetbrains.com/lp/devecosystem-2020/kotlin/

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinMultiplatformClientCodegen.java
@@ -28,6 +28,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
         // Versions
         public static final String KOTLIN_VERSION = "kotlinVersion";
         public static final String KTOR_VERSION = "ktorVersion";
+        public static final String KOTLINX_COROUTINES_VERSION = "kotlinxCoroutinesVersion";
         public static final String GRADLE_VERSION = "gradleVersion";
         public static final String ANDROID_GRADLE_VERSION = "androidGradleVersion";
         public static final String KOTLINX_DATETIME_VERSION = "kotlinxDatetimeVersion";
@@ -48,6 +49,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
             // Recommended choices: https://kotlinlang.org/releases.html
             public static final String KOTLIN_VERSION = "1.4.21";
             public static final String KTOR_VERSION = "1.4.1";
+            public static final String KOTLINX_COROUTINES_VERSION = "1.4.1";
             public static final String GRADLE_VERSION = "6.6.1";
             public static final String ANDROID_GRADLE_VERSION = "4.0.1";
             public static final String KOTLINX_DATETIME_VERSION = "0.1.1";
@@ -244,6 +246,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
 
         cliOptions.add(CliOption.newString(Options.KOTLIN_VERSION, "Sets the kotlin version used").defaultValue(Options.Defaults.KOTLIN_VERSION));
         cliOptions.add(CliOption.newString(Options.KTOR_VERSION, "Sets the ktor version used").defaultValue(Options.Defaults.KTOR_VERSION));
+        cliOptions.add(CliOption.newString(Options.KOTLINX_COROUTINES_VERSION, "Sets the kotlinx.coroutines version used").defaultValue(Options.Defaults.KOTLINX_COROUTINES_VERSION));
         cliOptions.add(CliOption.newString(Options.GRADLE_VERSION, "Sets the gradle version used").defaultValue(Options.Defaults.GRADLE_VERSION));
         cliOptions.add(CliOption.newString(Options.ANDROID_GRADLE_VERSION, "Sets the android gradle plugin version used").defaultValue(Options.Defaults.ANDROID_GRADLE_VERSION));
 
@@ -315,6 +318,7 @@ public class KotlinMultiplatformClientCodegen extends AbstractKotlinCodegen {
 
         String kotlinVersion = stringOption(Options.KOTLIN_VERSION, Options.Defaults.KOTLIN_VERSION);
         String ktorVersion = stringOption(Options.KTOR_VERSION, Options.Defaults.KTOR_VERSION);
+        String kotlinxCoroutinesVersion = stringOption(Options.KOTLINX_COROUTINES_VERSION, Options.Defaults.KOTLINX_COROUTINES_VERSION);
         String gradleVersion = stringOption(Options.GRADLE_VERSION, Options.Defaults.GRADLE_VERSION);
         String androidGradleVersion = stringOption(Options.ANDROID_GRADLE_VERSION, Options.Defaults.ANDROID_GRADLE_VERSION);
         String kotlinxDatetimeVersion = stringOption(Options.KOTLINX_DATETIME_VERSION, Options.Defaults.KOTLINX_DATETIME_VERSION);

--- a/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
@@ -11,6 +11,7 @@ group = "{{groupId}}"
 version = "{{artifactVersion}}"
 
 val ktorVersion = "{{ktorVersion}}"
+val kotlinxCoroutinesVersion = "{{kotlinxCoroutinesVersion}}"
 {{#dateLibraryKotlinx}}
 val kotlinxDatetimeVersion = "{{kotlinxDatetimeVersion}}"
 {{/dateLibraryKotlinx}}
@@ -75,6 +76,7 @@ kotlin {
                 api("io.ktor:ktor-client-core:$ktorVersion")
                 api("io.ktor:ktor-client-json:$ktorVersion")
                 api("io.ktor:ktor-client-serialization:$ktorVersion")
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
                 {{#dateLibraryKotlinx}}
                 api("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDatetimeVersion")
                 {{/dateLibraryKotlinx}}

--- a/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
@@ -12,6 +12,7 @@ version = "{{artifactVersion}}"
 
 val ktorVersion = "{{ktorVersion}}"
 val kotlinxCoroutinesVersion = "{{kotlinxCoroutinesVersion}}"
+val kotlinxSerializationVersion = "{{kotlinxSerializationVersion}}"
 {{#dateLibraryKotlinx}}
 val kotlinxDatetimeVersion = "{{kotlinxDatetimeVersion}}"
 {{/dateLibraryKotlinx}}
@@ -77,6 +78,7 @@ kotlin {
                 api("io.ktor:ktor-client-json:$ktorVersion")
                 api("io.ktor:ktor-client-serialization:$ktorVersion")
                 api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-json:kotlinxSerializationVersion")
                 {{#dateLibraryKotlinx}}
                 api("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDatetimeVersion")
                 {{/dateLibraryKotlinx}}

--- a/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
@@ -216,7 +216,7 @@ tasks {
 }
 {{/jvmEnabled}}
 
-<!-- force explicit versions for kotlin/kotlinx dependencies -->
+// force explicit versions for kotlin/kotlinx dependencies
 configurations.all {
     resolutionStrategy {
         eachDependency {

--- a/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/build.gradle.kts.mustache
@@ -215,3 +215,18 @@ tasks {
     }
 }
 {{/jvmEnabled}}
+
+<!-- force explicit versions for kotlin/kotlinx dependencies -->
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            when (requested.group) {
+                "org.jetbrains.kotlin" -> useVersion("{{kotlinVersion}}")
+                "org.jetbrains.kotlinx" -> when {
+                    requested.name.startsWith("kotlinx-coroutines") -> useVersion(kotlinxCoroutinesVersion)
+                    requested.name.startsWith("kotlinx-serialization") -> useVersion(kotlinxSerializationVersion)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Updated default kotlin/kotlinx dependencies to align with [recommendations](https://kotlinlang.org/releases.html)
- allow configuring version of kotlinx.coroutines
- allow configuring version of kotlinx.serialization
- force resolution for kotlin/kotlinx versions

Using the recommended Ktor 1.4.1 without explicitly declaring kotlinx.serialization results in using the older RC release and that combination causes issues with the new JS IR backend so we declare it explicitly, allow customisation and force resolution.