### PR TITLE
define request content type as application/json for default body param

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-multiplatform-client/api.mustache
@@ -159,6 +159,7 @@ public open class {{classname}} : ApiClientBase {
             {{#bodyParam}}
 
             // Body
+            contentType(ContentType.Application.Json)
             {{#required}}
             this.body = {{{paramName}}}
             {{/required}}


### PR DESCRIPTION
Currently, for requests with a (non Formdata) body param, body is being set to a given argument value but `ContentType` is not defined so when providing an object that can be serialised to Json as value - it throw the following error `java.lang.IllegalStateException: Fail to serialize body. Content has type: class ******** (Kotlin reflection is not available), but OutgoingContent expected.
If you expect serialized body, please check that you have installed the corresponding feature(like 'Json') and set 'Content-Type' header`.

According to Ktor [docs](https://ktor.io/docs/request.html#specifying-a-body-for-requests): "_If you install the JsonFeature, and set the content type to application/json you can use arbitrary instances as the body, and they will be serialised as JSON_".

So we might want to set `contentType(ContentType.Application.Json)` in that case (might want to do that only if the body param type is not a String nor a subtype of OutgoingContent).
Otherwise, the only option for consumer to avoid that error is to set a default ContentType for HttpClient requests:
```kotlin
defaultRequest {
    contentType(ContentType.Application.Json)
}
```